### PR TITLE
特定期間のメッセージを全取得し、１時間毎に何件投稿があったかを表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,4 +61,5 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'groupdate'
 gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
     gli (2.18.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    groupdate (4.1.1)
+      activesupport (>= 4.2)
     hashie (3.6.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -213,6 +215,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   chromedriver-helper
   coffee-rails (~> 4.2)
+  groupdate
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,6 +5,7 @@ class MessagesController < ApplicationController
   # GET /messages.json
   def index
     @messages = Message.all
+    @groupdates = @messages.group_by_hour(:timestamp).count
   end
 
   # GET /messages/1
@@ -62,13 +63,14 @@ class MessagesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_message
-      @message = Message.find(params[:id])
-    end
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def message_params
-      params.require(:message).permit(:channel_user_id, :text, :ts)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_message
+    @message = Message.find(params[:id])
+  end
+
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def message_params
+    params.require(:message).permit(:channel_user_id, :text, :ts)
+  end
 end

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -5,6 +5,24 @@
 <table>
   <thead>
     <tr>
+      <th>unit</th>
+      <th>count</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @groupdates.each do |unit, count| %>
+      <tr>
+        <td><%= unit %></td>
+        <td><%= count %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table>
+  <thead>
+    <tr>
       <th>Channel user</th>
       <th>Text</th>
       <th>Ts</th>

--- a/config/initializers/groupdate_initializer.py.rb
+++ b/config/initializers/groupdate_initializer.py.rb
@@ -1,0 +1,1 @@
+Groupdate.time_zone = 'Tokyo'

--- a/db/migrate/20190515073518_add_timestamp_column_to_message.rb
+++ b/db/migrate/20190515073518_add_timestamp_column_to_message.rb
@@ -1,0 +1,5 @@
+class AddTimestampColumnToMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :timestamp, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_073352) do
+ActiveRecord::Schema.define(version: 2019_05_15_073518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2019_05_14_073352) do
     t.string "ts", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "timestamp", null: false
     t.index ["channel_user_id"], name: "index_messages_on_channel_user_id"
   end
 

--- a/lib/tasks/pull_data.rake
+++ b/lib/tasks/pull_data.rake
@@ -205,7 +205,7 @@ namespace :pull_data do
                                           ts: message.ts)
         m.attributes = {
           text: message.text,
-          timestamp: Time.at(*m.ts.split('.').map(&:to_i)).strftime('%F %T.%6N')
+          timestamp: Time.at(*m.ts.split('.').map(&:to_i)).in_time_zone('UTC').strftime('%F %T.%6N')
         }
         m.save!
 

--- a/lib/tasks/pull_data.rake
+++ b/lib/tasks/pull_data.rake
@@ -141,7 +141,7 @@ namespace :pull_data do
     # 現在は、開始・終了時間でpagingをしている ref. https://api.slack.com/methods/conversations.history
     # 全てのメッセージ一覧を取得する場合は、こちら ref. https://api.slack.com/docs/pagination
     now = Time.now.strftime("%s.%6N")
-    oldest = Time.now..days_ago(3).strftime("%s.%6N")
+    oldest = Time.now.days_ago(3).strftime("%s.%6N")
     channels.each.with_index(1) do |channel, i|
       # 不必要に保存しない
       next unless channel.is_channel
@@ -195,7 +195,8 @@ namespace :pull_data do
           m = Message.find_or_initialize_by(channel_user: channel_user,
                                             ts: message.ts)
           m.attributes = {
-            text: message.text
+            text: message.text,
+            timestamp: Time.at(*m.ts.split('.').map(&:to_i)).strftime('%F %T.%6N')
           }
           m.save!
 


### PR DESCRIPTION
## 概要
- 特定期間のメッセージを全取得 #4 
- ワークスペース全体で、1時間毎に何件メッセージ投稿があったかの表を作成

## 詳細（主に技術的変更点）
- ActiveRecord Associationの定義
- `gem 'groupdate'`の追加
  - groupingに必要なcolumnを`messages`テーブルに追加
- slack apiで、メッセージ取得期間を指定
  - pagingはresponseに`has_more: true`があるかどうかで判定

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
- /messages へアクセス

## 保留した項目・TODOリスト
- デザインの美しさ

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
- slack api (メッセージ一覧取得)
 - https://api.slack.com/methods/conversations.history