### PR TITLE
Chartjsを追加

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,6 +6,12 @@ class MessagesController < ApplicationController
   def index
     @messages = Message.all
     @groupdates = @messages.group_by_hour(:timestamp).count
+
+    labels = @groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }
+    data = @groupdates.values
+
+    @line_data = ChartjsLine.new(data: data,
+                                 labels: labels).with_default_style
   end
 
   # GET /messages/1

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,9 +7,7 @@ class MessagesController < ApplicationController
     @messages = Message.all
     @groupdates = @messages.group_by_hour(:timestamp).count
 
-    labels = @groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }
-    data = @groupdates.values
-
+    labels, data = chart_data(@groupdates)
     @line_data = ChartjsLine.new(data: data,
                                  labels: labels).with_default_style
   end
@@ -78,5 +76,9 @@ class MessagesController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
     params.require(:message).permit(:channel_user_id, :text, :ts)
+  end
+
+  def chart_data(groupdates)
+    [groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }, groupdates.values]
   end
 end

--- a/app/javascript/components/ChartjsLine.js
+++ b/app/javascript/components/ChartjsLine.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {Line} from 'react-chartjs-2';
+
+class ChartjsLine extends React.Component {
+  render() {
+    return (
+      <div>
+        <Line data={this.props.data}/>
+      </div>
+    );
+  }
+}
+
+export default ChartjsLine

--- a/app/models/chartjs_line.rb
+++ b/app/models/chartjs_line.rb
@@ -1,0 +1,34 @@
+class ChartjsLine
+  include ActiveModel::Model
+  attr_accessor :data, :labels
+
+  # ref. https://www.chartjs.org/docs/latest/charts/line.html
+  def with_default_style
+    {
+      labels: labels,
+      datasets: [
+        {
+          labels: 'count',
+          fill: false,
+          lineTension: 0.1,
+          backgroundColor: 'rgba(75,192,192,0.4)',
+          borderColor: 'rgba(75,192,192,1)',
+          borderCapStyle: 'butt',
+          borderDash: [],
+          borderDashOffset: 0.0,
+          borderJoinStyle: 'miter',
+          pointBorderColor: 'rgba(75,192,192,1)',
+          pointBackgroundColor: '#fff',
+          pointBorderWidth: 1,
+          pointHoverRadius: 5,
+          pointHoverBackgroundColor: 'rgba(75,192,192,1)',
+          pointHoverBorderColor: 'rgba(220,220,220,1)',
+          pointHoverBorderWidth: 2,
+          pointRadius: 1,
+          pointHitRadius: 10,
+          data: data
+        }
+      ]
+    }
+  end
+end

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,6 +1,7 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Messages</h1>
+<%= react_component('ChartjsLine', data: @line_data) %>
 
 <table>
   <thead>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@babel/preset-react": "^7.0.0",
     "@rails/webpacker": "^4.0.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "chart.js": "^2.8.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-chartjs-2": "^2.7.6",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-chartjs-2": "^2.7.6",
     "react-dom": "^16.8.6",
     "react_ujs": "^2.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,7 +3856,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -5449,7 +5449,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5597,6 +5597,14 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-chartjs-2@^2.7.6:
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-2.7.6.tgz#b8cd29bed00bf55b9e8172b06466b4ecf2b86bfb"
+  integrity sha512-xDr0jhgt/o26atftXxTVsepz+QYZI2GNKBYpxtLvYgwffLUm18a9n562reUJAHvuwKsy2v+qMlK5HyjFtSW0mg==
+  dependencies:
+    lodash "^4.17.4"
+    prop-types "^15.5.8"
 
 react-dom@^16.8.6:
   version "16.8.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,29 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chart.js@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.8.0.tgz#b703b10d0f4ec5079eaefdcd6ca32dc8f826e0e9"
+  integrity sha512-Di3wUL4BFvqI5FB5K26aQ+hvWh8wnP9A3DWGvXHVkO13D3DSnaSsdZx29cXlEsYKVkn1E2az+ZYFS4t0zi8x0w==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.3.0.tgz#0e7e1e8dba37eae8415fd3db38bf572007dd958f"
+  integrity sha512-hEvVheqczsoHD+fZ+tfPUE+1+RbV6b+eksp2LwAhwRTVXEjCSEavvk+Hg3H6SZfGlPh/UfmWKGIvZbtobOEm3g==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^0.5.3"
+
 chokidar@^2.0.2, chokidar@^2.1.5:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
@@ -1679,6 +1702,11 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
@@ -4138,6 +4166,11 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdir
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.10.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## 概要
ChartjsのReact版を追加し、１時間毎のメッセージ数を表示

## 詳細（主に技術的変更点）
- `chart.js` `react-chartjs-2`の`node_module`を追加
- ChartJSのLineChartに渡す用のデータを保持するモデル`ChartsjLine`の作成

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
- `/messages` へアクセス

## 保留した項目・TODOリスト
特になし

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
- 参考URL
  - https://github.com/jerairrest/react-chartjs-2
  - https://www.chartjs.org/docs/latest/charts/line.html