### PR TITLE
APIサーバーからメッセージ推移を取得して表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'groupdate'
 gem 'kaminari'
+gem 'rack-cors'
 gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.7)
+    rack-cors (1.0.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -233,6 +234,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.3)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,6 +10,12 @@ class MessagesController < ApplicationController
     @groupdates = messages.group_by_hour(:timestamp).count
   end
 
+  def groupdate
+    groupdates = Message.all.group_by_hour(:timestamp).count
+    labels, data = chart_data(groupdates)
+    render json: ChartjsLine.new(data: data, labels: labels).with_default_style
+  end
+
   # GET /messages/1
   # GET /messages/1.json
   def show
@@ -74,5 +80,9 @@ class MessagesController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def message_params
     params.require(:message).permit(:channel_user_id, :text, :ts)
+  end
+
+  def chart_data(groupdates)
+    [groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }, groupdates.values]
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,8 +12,7 @@ class MessagesController < ApplicationController
 
   def groupdate
     groupdates = Message.all.group_by_hour(:timestamp).count
-    labels, data = chart_data(groupdates)
-    render json: ChartjsLine.new(data: data, labels: labels).with_default_style
+    render json: ChartjsLine.new(groupdates: groupdates).with_default_style
   end
 
   # GET /messages/1
@@ -82,7 +81,4 @@ class MessagesController < ApplicationController
     params.require(:message).permit(:channel_user_id, :text, :ts)
   end
 
-  def chart_data(groupdates)
-    [groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }, groupdates.values]
-  end
 end

--- a/app/models/chartjs_line.rb
+++ b/app/models/chartjs_line.rb
@@ -36,6 +36,6 @@ class ChartjsLine
   private
 
   def chart_data(groupdates)
-    [groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }, groupdates.values]
+    [groupdates.keys.map { |ts| I18n.l(ts, format: :short) }, groupdates.values]
   end
 end

--- a/app/models/chartjs_line.rb
+++ b/app/models/chartjs_line.rb
@@ -1,9 +1,10 @@
 class ChartjsLine
   include ActiveModel::Model
-  attr_accessor :data, :labels
+  attr_accessor :groupdates
 
   # ref. https://www.chartjs.org/docs/latest/charts/line.html
   def with_default_style
+    labels, data = chart_data(groupdates)
     {
       labels: labels,
       datasets: [
@@ -30,5 +31,11 @@ class ChartjsLine
         }
       ]
     }
+  end
+
+  private
+
+  def chart_data(groupdates)
+    [groupdates.keys.map { |ts| ts.strftime('%m/%d %k:%M') }, groupdates.values]
   end
 end

--- a/app/models/chartjs_line.rb
+++ b/app/models/chartjs_line.rb
@@ -1,0 +1,34 @@
+class ChartjsLine
+  include ActiveModel::Model
+  attr_accessor :data, :labels
+
+  # ref. https://www.chartjs.org/docs/latest/charts/line.html
+  def with_default_style
+    {
+      labels: labels,
+      datasets: [
+        {
+          label: 'count',
+          fill: false,
+          lineTension: 0.1,
+          backgroundColor: 'rgba(75,192,192,0.4)',
+          borderColor: 'rgba(75,192,192,1)',
+          borderCapStyle: 'butt',
+          borderDash: [],
+          borderDashOffset: 0.0,
+          borderJoinStyle: 'miter',
+          pointBorderColor: 'rgba(75,192,192,1)',
+          pointBackgroundColor: '#fff',
+          pointBorderWidth: 1,
+          pointHoverRadius: 5,
+          pointHoverBackgroundColor: 'rgba(75,192,192,1)',
+          pointHoverBorderColor: 'rgba(220,220,220,1)',
+          pointHoverBorderWidth: 2,
+          pointRadius: 1,
+          pointHitRadius: 10,
+          data: data
+        }
+      ]
+    }
+  end
+end

--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+REACT_APP_API_ENDPOINT_BASE=http://localhost:4000

--- a/client/package.json
+++ b/client/package.json
@@ -6,9 +6,11 @@
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
     "axios": "^0.18.0",
+    "chart.js": "^2.8.0",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-chartjs-2": "^2.7.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
     "recharts": "^1.6.0"

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.3",
     "@material-ui/icons": "^3.0.2",
+    "axios": "^0.18.0",
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -20,7 +20,7 @@ import SimpleTable from './SimpleTable';
 import axios from 'axios'
 
 const drawerWidth = 240;
-const ENDPONT = 'http://localhost:3000';
+const ENDPOINT_BASE = process.env.REACT_APP_API_ENDPOINT_BASE;
 
 const styles = theme => ({
   root: {
@@ -106,12 +106,12 @@ class Dashboard extends React.Component {
       open: true,
       groupdate: {}
     };
-    this.getData()
+    this.getData();
   }
 
   getData() {
     axios
-      .get(ENDPONT + '/messages/groupdate')
+      .get(ENDPOINT_BASE + '/messages/groupdate')
       .then(results => {
         const data = results.data;
         this.setState({

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -17,8 +17,10 @@ import NotificationsIcon from '@material-ui/icons/Notifications';
 import {mainListItems, secondaryListItems} from './listItems';
 import SimpleLineChart from './SimpleLineChart';
 import SimpleTable from './SimpleTable';
+import axios from 'axios'
 
 const drawerWidth = 240;
+const ENDPONT = 'http://localhost:3000';
 
 const styles = theme => ({
   root: {
@@ -98,9 +100,25 @@ const styles = theme => ({
 });
 
 class Dashboard extends React.Component {
-  state = {
-    open: true,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: true,
+      groupdate: {}
+    };
+    this.getData()
+  }
+
+  getData() {
+    axios
+      .get(ENDPONT + '/messages/groupdate')
+      .then(results => {
+        const data = results.data;
+        this.setState({
+          groupdate: data
+        });
+      });
+  }
 
   handleDrawerOpen = () => {
     this.setState({open: true});
@@ -168,10 +186,10 @@ class Dashboard extends React.Component {
         <main className={classes.content}>
           <div className={classes.appBarSpacer}/>
           <Typography variant="h4" gutterBottom component="h2">
-            Orders
+            メッセージ数
           </Typography>
           <Typography component="div" className={classes.chartContainer}>
-            <SimpleLineChart/>
+            <SimpleLineChart data={this.state.groupdate}/>
           </Typography>
           <Typography variant="h4" gutterBottom component="h2">
             Products

--- a/client/src/components/SimpleLineChart.js
+++ b/client/src/components/SimpleLineChart.js
@@ -1,38 +1,17 @@
 import React from 'react';
-import ResponsiveContainer from 'recharts/lib/component/ResponsiveContainer';
-import LineChart from 'recharts/lib/chart/LineChart';
-import Line from 'recharts/lib/cartesian/Line';
-import XAxis from 'recharts/lib/cartesian/XAxis';
-import YAxis from 'recharts/lib/cartesian/YAxis';
-import CartesianGrid from 'recharts/lib/cartesian/CartesianGrid';
-import Tooltip from 'recharts/lib/component/Tooltip';
-import Legend from 'recharts/lib/component/Legend';
+import {Line} from 'react-chartjs-2';
 
-const data = [
-  {name: 'Mon', Visits: 2200, Orders: 3400},
-  {name: 'Tue', Visits: 1280, Orders: 2398},
-  {name: 'Wed', Visits: 5000, Orders: 4300},
-  {name: 'Thu', Visits: 4780, Orders: 2908},
-  {name: 'Fri', Visits: 5890, Orders: 4800},
-  {name: 'Sat', Visits: 4390, Orders: 3800},
-  {name: 'Sun', Visits: 4490, Orders: 4300},
-];
-
-function SimpleLineChart() {
-  return (
-    // 99% per https://github.com/recharts/recharts/issues/172
-    <ResponsiveContainer width="99%" height={320}>
-      <LineChart data={data}>
-        <XAxis dataKey="name" f/>
-        <YAxis/>
-        <CartesianGrid vertical={false} strokeDasharray="3 3"/>
-        <Tooltip/>
-        <Legend/>
-        <Line type="monotone" dataKey="Visits" stroke="#82ca9d"/>
-        <Line type="monotone" dataKey="Orders" stroke="#8884d8" activeDot={{r: 8}}/>
-      </LineChart>
-    </ResponsiveContainer>
-  );
+class SimpleLineChart extends React.Component {
+  render() {
+    return (
+      <div>
+        <Line data={this.props.data} height={400} options={{
+          maintainAspectRatio: false,
+          responsive: true,
+        }}/>
+      </div>
+    );
+  }
 }
 
 export default SimpleLineChart;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2478,6 +2478,29 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.8.0.tgz#b703b10d0f4ec5079eaefdcd6ca32dc8f826e0e9"
+  integrity sha512-Di3wUL4BFvqI5FB5K26aQ+hvWh8wnP9A3DWGvXHVkO13D3DSnaSsdZx29cXlEsYKVkn1E2az+ZYFS4t0zi8x0w==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.3.0.tgz#0e7e1e8dba37eae8415fd3db38bf572007dd958f"
+  integrity sha512-hEvVheqczsoHD+fZ+tfPUE+1+RbV6b+eksp2LwAhwRTVXEjCSEavvk+Hg3H6SZfGlPh/UfmWKGIvZbtobOEm3g==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^0.5.3"
+
 chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
@@ -2612,6 +2635,11 @@ collection-visit@^1.0.0:
   dependencies:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
+
+color-convert@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
@@ -6196,7 +6224,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.4:
+"lodash@>=3.5 <5", lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6494,6 +6522,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.10.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -8005,7 +8038,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8174,6 +8207,14 @@ react-app-polyfill@^1.0.1:
     raf "3.4.1"
     regenerator-runtime "0.13.2"
     whatwg-fetch "3.0.0"
+
+react-chartjs-2@^2.7.6:
+  version "2.7.6"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-2.7.6.tgz#b8cd29bed00bf55b9e8172b06466b4ecf2b86bfb"
+  integrity sha512-xDr0jhgt/o26atftXxTVsepz+QYZI2GNKBYpxtLvYgwffLUm18a9n562reUJAHvuwKsy2v+qMlK5HyjFtSW0mg==
+  dependencies:
+    lodash "^4.17.4"
+    prop-types "^15.5.8"
 
 react-dev-utils@^9.0.1:
   version "9.0.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1901,6 +1901,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 axobject-query@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -4228,7 +4236,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.3.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
   integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module OrgAnalisis
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,16 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'localhost:3001'
+
+    # ref. https://qiita.com/sugo/items/9c5f9cc5d88e6d7efa2d
+    # 全てのリソースに対して次のものを許可する
+    resource "*",
+             # APIサーバに対するリクエストにどんなヘッダでもつけることを許可する
+             headers: :any,
+             # methodsで指定したメソッドでのリソースへのアクセスを許可する
+             methods: [:get],
+             # exposeで指定したものは、レスポンスのHTTPヘッダとして公開を許可する（別オリジンからのリクエスト者でも見えるようにする）
+             expose: []
+  end
+end
+

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:3001'
+    origins 'localhost:3000'
 
     # ref. https://qiita.com/sugo/items/9c5f9cc5d88e6d7efa2d
     # 全てのリソースに対して次のものを許可する
@@ -13,4 +13,3 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
              expose: []
   end
 end
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,206 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          pb: PB
+          eb: EB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,7 +9,7 @@ threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 4000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   resources :reactions
   resources :emojis
-  resources :messages
+  resources :messages do
+    get :groupdate, on: :collection
+  end
   resources :channels
   resources :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要
RailsのAPIサーバーから１時間毎のメッセージ投稿数を取得し表示

## 詳細（主に技術的変更点）
- やはり見た目の良いChart.jsを導入
- CORS設定で、Reactアプリ(localhost:3001)からRailsAPIサーバー(localhost:3000)を呼び出せるように

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）
- メッセージ数が表示される
- スクリーンショット（without data）
![image](https://user-images.githubusercontent.com/17138455/57997807-97032a80-7b09-11e9-9c76-15671af51afd.png)

## 保留した項目・TODOリスト
\-
## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
- clientディレクトリにReactAppが入ってます。