### PR TITLE
Add setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
-# README
+# OrgAnalisis
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## セットアップ方法
 
-Things you may want to cover:
+以下のソフトウェアをインストールしておく必要があります。
 
-* Ruby version
+- Ruby 2.6.2
+- PostgreSQL
+- Yarn
+- Node >=8.10
 
-* System dependencies
+APIサーバを起動するために以下のコマンドを実行します。
 
-* Configuration
+```bash
+$ git clone https://github.com/machisuke/OrgAnalisis.git
+$ cd OrgAnalisis
+$ bundle install
+$ bundle exec rails db:setup
+$ bundle exec rails server -p 4000
+```
 
-* Database creation
+実行後、[http://localhost:4000](http://localhost:4000) が表示されれば起動成功です。
 
-* Database initialization
+また、フロントエンドのサーバを起動するために以下のコマンドを実行します。
 
-* How to run the test suite
+```bash
+$ cd path/to/OrgAnalisis
+$ cd client
+$ yarn
+$ yarn start
+```
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+実行後、[http://localhost:3000](http://localhost:3000) が表示されれば起動成功です。


### PR DESCRIPTION
## 概要
Fix README

## 詳細（主に技術的変更点）

手元で動かそうとしたときセットアップ方法がまとまっていると捗るため、READMEにセットアップ方法をまとめてみました。

## 使い方・確認方法（設定変更やコマンドが必要ならばそれも書く）

https://github.com/shimbaco/OrgAnalisis/tree/update-readme をご参照ください。

## 保留した項目・TODOリスト

特に無いです。(たぶん)

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）

Create React Appが使用するデフォルトのポート番号がRailsと同じ `3000` 番だったので、ひとまずRailsのほうを `4000` 番で起動するように記述しました。期待した番号でない場合教えてもらえればと思います :bow:
